### PR TITLE
Adds suport for object templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,13 @@ module.exports = function(params, envs) {
     }
   });
 
+  //apply configuration element templates
+  keys.filter(property =>
+    schema[property].type === 'object' && schema[property].template
+  ).forEach(property =>
+    result[property] = _.defaults({}, result[property], schema[property].template)
+  );
+
   //validate schemas
   keys.forEach(property => {
     const config = schema[property];

--- a/test/xenv.tests.js
+++ b/test/xenv.tests.js
@@ -208,4 +208,64 @@ describe('xenv', function () {
     assert.throws(() => xenv({ schema }, input), /The predefined type for FOO "doris" does not exists/);
   });
 
+  it('should merge the object template with values defined in the configuration', function () {
+    const schema = {
+      'FOO' : {
+        type: "object",
+        template: {
+          a: true,
+          b: false
+        }
+      }
+    };
+
+    const input = { FOO: {c: true}};
+
+    const output = xenv({schema}, input);
+
+    assert.equal(output.FOO.a, true);
+    assert.equal(output.FOO.b, false);
+    assert.equal(output.FOO.c, true);
+
+  });
+
+  it('should replace the object template values with values defined in the configuration', function () {
+    const schema = {
+      'FOO' : {
+        type: "object",
+        template: {
+          a: true,
+          b: false
+        }
+      }
+    };
+
+    const input = { FOO: {b: true}};
+
+    const output = xenv({schema}, input);
+
+    assert.equal(output.FOO.a, true);
+    assert.equal(output.FOO.b, true);
+
+  });
+
+  it('should use the template values if no values are defined in the configuration', function () {
+    const schema = {
+      'FOO' : {
+        type: "object",
+        template: {
+          a: true,
+          b: false
+        }
+      }
+    };
+
+    const input = { };
+
+    const output = xenv({schema}, input);
+
+    assert.equal(output.FOO.a, true);
+    assert.equal(output.FOO.b, false);
+
+  });
 });


### PR DESCRIPTION
Adds the ability to define a `template` property in the schema of properties fo type **object** that will be merged with the object passed in the configuration.

This allows scenarios where only a subset of the properties of the object will be defined in the configuration but we want to maintain the remanining properties defaults. The name is different from `default` to avoid changes in the current behavior.