### PR TITLE
fix boolean string parsing

### DIFF
--- a/lib/templates.js
+++ b/lib/templates.js
@@ -4,7 +4,7 @@ const ms  = require('ms');
 
 module.exports.int = function(params) {
   const schema = _.extend({
-    parse:    parseInt,
+    parse: parseInt,
     validate: n => n === parseInt(n, 10)
   }, params || {});
   return schema;
@@ -28,7 +28,16 @@ module.exports.object = function(params) {
 
 module.exports.boolean = function(params) {
   const schema = _.extend({
-    parse:    v => Boolean(v),
+    parse:    v => {
+      switch (v) {
+        case 'true':
+          return true;
+        case 'false':
+          return false;
+        default:
+          return Boolean(v);
+      }
+    },
     validate: v => typeof v === 'boolean'
   }, params || {});
   return schema;

--- a/test/xenv.templates.tests.js
+++ b/test/xenv.templates.tests.js
@@ -83,11 +83,13 @@ describe('xenvTemplates.templates', function() {
       assert.notOk(schema['parse']());
       assert.notOk(schema['parse'](null));
       assert.notOk(schema['parse'](false));
+      assert.notOk(schema['parse']('false'));
 
       assert.ok(schema['parse']('1'));
       assert.ok(schema['parse']('tokads'));
       assert.ok(schema['parse'](' '));
       assert.ok(schema['parse'](true));
+      assert.ok(schema['parse']('true'));
 
       assert.notOk(schema['validate']('tete'));
       assert.notOk(schema['validate'](10.12));


### PR DESCRIPTION
Parsing functions are meant to be run only for strings according to https://github.com/ziluvatar/xenv/blob/05204e70feb94350e269cc21ab1d47ce99ecf763/index.js#L52

In the case of booleans the test checks different values, however, the usual `ENV_VARIABLE=false` won't work fine because `Boolean('false') === true`. I didn't want to modify the logic too much and focus on the bug, IMO inputs like `ENV_VARIABLE=whatever` should error in first place instead of returning `true`. In any case, this changes fixes the general case.

Maybe a major version is needed since consumers could be, wrongly, relying on `VAR=false` today and may get sudden configuration change by upgrading blindly.